### PR TITLE
fix: handle nullable Karakeep bookmark fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ Before you can use this plugin, you will need to configure it with your local Ka
 
 - `Karakeep Base Address`: This is the base URL of your local Karakeep instance. For example, if you run Karakeep on http://localhost:8080, then this should be set to `http://localhost:8080`.
 
-- `Karakeep API Key`: This is the API key that allows the plugin to access your Karakeep bookmarks. You can obtain this key from the Karakeep web interface by going to your profile settings > User Settings > API Keys page and clicking on "New API Key".
+- `Karakeep API Key`: This is the API key that allows the plugin to search and open your Karakeep bookmarks. You can obtain this key from the Karakeep web interface by going to your profile settings > User Settings > API Keys page and clicking on "New API Key".
+
+### API key permissions
+
+The plugin only calls `GET /api/v1/bookmarks/search`, so the minimum Karakeep API key scope is:
+
+- `bookmarks:read`
+
+A key with `bookmarks:readwrite` or `fullaccess` will also work, but is not required. Prefer `bookmarks:read` for day-to-day use because the plugin does not create, edit, or delete bookmarks.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ A key with `bookmarks:readwrite` or `fullaccess` will also work, but is not requ
 
 ## Usage
 
-Once installed, you can activate the Karakeep plugin by using the action keyword `ho`. Simply type `ho` followed by your search query to find matching bookmarks stored in Karakeep.
+Once installed, you can activate the Karakeep plugin by using the default action keyword `ka`. Simply type `ka` followed by your search query to find matching bookmarks stored in Karakeep.
 
 ### Example
 
 To search for a bookmark related to "Python", you would use the following command in FlowLauncher:
 
 ```
-ho Python
+ka Python
 ```
 
 ## Features

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name": "Karakeep",
     "Description": "Karakeep (former Hoarder) Plugin",
     "Author": "Robert Verdam",
-    "Version": "1.0.4",
+    "Version": "1.0.5",
     "Language": "python",
     "Website": "https://github.com/rverdam/Flow.Launcher.Plugin.Karakeep",
     "IcoPath": "Images\\app.png",

--- a/plugin/karakeep.py
+++ b/plugin/karakeep.py
@@ -2,7 +2,7 @@ import requests
 
 class KarakeepAPI:
     def __init__(self, base_url: str, api_key: str):
-        self.base_url = base_url
+        self.base_url = base_url.rstrip('/')
         self.api_key = api_key
 
     def search_bookmarks(self, query: str):
@@ -13,11 +13,12 @@ class KarakeepAPI:
         params = {'q': query}
         
         try:
-            response = requests.get(endpoint, headers=headers, params=params)
+            response = requests.get(endpoint, headers=headers, params=params, timeout=10)
         except requests.exceptions.RequestException as e:
             raise ConnectionError(e)
         
         if response.status_code == 200:
-            return response.json().get('bookmarks')
+            return response.json().get('bookmarks') or []
         else:
             response.raise_for_status()
+            return []

--- a/plugin/results.py
+++ b/plugin/results.py
@@ -7,6 +7,13 @@ from html import unescape
 from strip_markdown import strip_markdown
 from plugin.karakeep import KarakeepAPI
 
+
+def _html_text(value, default="") -> str:
+    """Return a display-safe string for nullable Karakeep API fields."""
+    if value is None:
+        return default
+    return unescape(str(value))
+
 def error_results(error: str, JsonRPCAction=None):
     """
     Returns a Result representing a Karakeep plugin error.
@@ -59,17 +66,24 @@ def query_result(item) -> Result:
     :param item: a Karakeep API query item
     :return: a Result object
     """
-    content = item.get("content")
+    content = item.get("content") or {}
     match content.get("type"):
         case "link":
             # If the content type is a link, then we have a title, subtitle and
             # an icon path. The json rpc action is a function that will be
             # called when the user clicks on the result.
-            title = content.get("title")
-            subtitle = unescape(content.get("description"))
-            icon_path = content.get("imageUrl")
+            url = (
+                content.get("url")
+                or f"{settings().get('karakeepBaseAddress')}/dashboard/preview/{item.get('id')}"
+            )
+            title = content.get("title") or item.get("title") or url or "Untitled link"
+            subtitle = _html_text(
+                content.get("description"),
+                item.get("summary") or item.get("note") or "",
+            )
+            icon_path = content.get("imageUrl") or content.get("favicon")
             context_data = [{
-                "url": content.get("url"),
+                "url": url,
                 "action": "copy_url"
             },
             {
@@ -77,7 +91,7 @@ def query_result(item) -> Result:
                  "action": "open_url"
             }
             ]
-            json_rpc_action = open_url(content.get("url"))
+            json_rpc_action = open_url(url)
             return Result(
                 Title=title, SubTitle=subtitle, IcoPath=icon_path,
                 ContextData=context_data, JsonRPCAction=json_rpc_action
@@ -88,17 +102,18 @@ def query_result(item) -> Result:
             # an icon path. The json rpc action is a function that will be
             # called when the user clicks on the result.
             url = f"{settings().get('karakeepBaseAddress')}/dashboard/preview/{item.get('id')}"
-            firstNoteLine = strip_markdown(content.get('text').split('\n')[0])
+            text = content.get('text') or ""
+            firstNoteLine = strip_markdown(text.split('\n')[0])
             title = item.get("title") if item.get("title") else firstNoteLine
             subtitle = firstNoteLine
-            title = f"Note: {title}"
+            title = f"Note: {title or 'Untitled note'}"
             json_rpc_action = open_url(url)
             context_data = [{
-                "text": content.get("text"),
+                "text": text,
                 "action": "copy_markdown_text"
             }]
             return Result(
-                Title=title, CopyText=content.get("text"),
+                Title=title, CopyText=text,
                 SubTitle=subtitle,
                 IcoPath=COPY,
                 ContextData=context_data, JsonRPCAction=json_rpc_action
@@ -112,9 +127,9 @@ def query_results(Karakeep: KarakeepAPI, query: str):
     :param query: the search query
     :yield: a sequence of Result objects
     """
-    search = Karakeep.search_bookmarks(query)
+    search = Karakeep.search_bookmarks(query) or []
     for item in search:
-        content = item.get("content")
+        content = item.get("content") or {}
         if content.get("type") in ("link", "text"):
             yield query_result(item)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+for relative in (".", "lib", "plugin"):
+    path = str(ROOT / relative)
+    if path not in sys.path:
+        sys.path.insert(0, path)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,0 +1,109 @@
+import pytest
+
+from plugin.karakeep import KarakeepAPI
+from plugin.results import query_result, query_results
+
+
+class DummySettings(dict):
+    def get(self, key, default=None):
+        if key == "karakeepBaseAddress":
+            return "https://karakeep.example"
+        return super().get(key, default)
+
+
+def test_link_result_allows_null_description(monkeypatch):
+    monkeypatch.setattr("plugin.results.settings", lambda: DummySettings())
+    item = {
+        "id": "bookmark-id",
+        "content": {
+            "type": "link",
+            "url": "https://example.com/article",
+            "title": "Example Article",
+            "description": None,
+            "imageUrl": None,
+        },
+    }
+
+    result = query_result(item).as_dict()
+
+    assert result["Title"] == "Example Article"
+    assert result["SubTitle"] == ""
+    assert result["JsonRPCAction"]["parameters"][0] == "https://example.com/article"
+
+
+def test_link_result_uses_url_when_title_is_null(monkeypatch):
+    monkeypatch.setattr("plugin.results.settings", lambda: DummySettings())
+    item = {
+        "id": "bookmark-id",
+        "content": {
+            "type": "link",
+            "url": "https://example.com/no-title",
+            "title": None,
+            "description": "Tom &amp; Jerry",
+            "imageUrl": None,
+        },
+    }
+
+    result = query_result(item).as_dict()
+
+    assert result["Title"] == "https://example.com/no-title"
+    assert result["SubTitle"] == "Tom & Jerry"
+
+
+def test_query_results_skips_items_without_supported_content():
+    class FakeKarakeep:
+        def search_bookmarks(self, query):
+            assert query == "needle"
+            return [
+                {"id": "missing-content", "content": None},
+                {"id": "asset", "content": {"type": "asset"}},
+                {"id": "link", "content": {"type": "link", "url": "https://example.com", "title": "Example", "description": None}},
+            ]
+
+    results = [result.as_dict() for result in query_results(FakeKarakeep(), "needle")]
+
+    assert [result["Title"] for result in results] == ["Example"]
+
+
+class FakeResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def json(self):
+        return self.payload
+
+    def raise_for_status(self):
+        raise AssertionError("raise_for_status should not be called for 200 responses")
+
+
+def test_search_bookmarks_returns_empty_list_when_response_has_no_bookmarks(monkeypatch):
+    api = KarakeepAPI("https://karakeep.example", "secret")
+    monkeypatch.setattr("plugin.karakeep.requests.get", lambda *args, **kwargs: FakeResponse({}))
+
+    assert api.search_bookmarks("needle") == []
+
+
+def test_search_bookmarks_sends_bearer_token_and_query(monkeypatch):
+    requests = []
+
+    def fake_get(url, **kwargs):
+        requests.append((url, kwargs))
+        return FakeResponse({"bookmarks": []})
+
+    api = KarakeepAPI("https://karakeep.example/", "secret")
+    monkeypatch.setattr("plugin.karakeep.requests.get", fake_get)
+
+    api.search_bookmarks("needle")
+
+    assert requests == [
+        (
+            "https://karakeep.example/api/v1/bookmarks/search",
+            {
+                "headers": {"Authorization": "Bearer secret"},
+                "params": {"q": "needle"},
+                "timeout": 10,
+            },
+        )
+    ]


### PR DESCRIPTION
## Summary
- Fix Flow Launcher Python plugin crash when Karakeep returns nullable bookmark fields, especially `content.description: null`.
- Add defensive handling for missing content/title/text/bookmarks and trailing slashes in the Karakeep base URL.
- Document the minimum Karakeep API key scope for this plugin as `bookmarks:read`.
- Add regression tests for the nullable-field crash and API wrapper behavior.

## Test plan
- `pytest -q`
- `python -m compileall -q plugin tests`
- `python -m json.tool plugin.json >/dev/null`
- Verified `run.py` JSON-RPC query against a live Karakeep instance returned 20 results with zero null subtitles.

Fixes #4

## Validated with
- Flow Launcher 2.1.2
- Karakeep v0.32.0
